### PR TITLE
Add authentication and rate limiting decorators

### DIFF
--- a/safe_mcp/__init__.py
+++ b/safe_mcp/__init__.py
@@ -6,7 +6,7 @@ and other security threats when using external data.
 """
 
 from .core import SecuredResponse, TrustLevel
-from .decorators import safe, unsafe, sanitize, validate_inputs
+from .decorators import safe, unsafe, sanitize, validate_inputs, require_auth, ratelimit
 
 __all__ = [
     "SecuredResponse",
@@ -15,6 +15,8 @@ __all__ = [
     "unsafe",
     "sanitize",
     "validate_inputs",
+    "require_auth",
+    "ratelimit",
 ]
 
 __version__ = "0.1.0"

--- a/safe_mcp/config.py
+++ b/safe_mcp/config.py
@@ -1,0 +1,15 @@
+from dataclasses import dataclass
+from typing import Callable, Optional
+
+
+@dataclass
+class MCPConfig:
+    """Configuration for authentication and rate limiting."""
+
+    auth_validator: Optional[Callable[[str], bool]] = None
+    ratelimit_capacity: int = 60
+    ratelimit_refill_rate: float = 1.0  # tokens per second
+
+
+# Global configuration instance
+config = MCPConfig()

--- a/safe_mcp/decorators.py
+++ b/safe_mcp/decorators.py
@@ -12,7 +12,13 @@ from .utils.patterns import (
     WARNING_UNSAFE_DECORATOR_DEFAULT,
     WARNING_SANITIZATION_SKIPPED,
     WARNING_INPUT_VALIDATION_FAILED,
+    WARNING_AUTH_TOKEN_MISSING,
+    WARNING_AUTH_TOKEN_INVALID,
+    WARNING_RATE_LIMIT_EXCEEDED,
 )
+from .config import config
+import asyncio
+import time
 
 
 T = TypeVar("T", bound=Callable[..., Any])
@@ -171,3 +177,119 @@ def validate_inputs(validator_func: Callable):
         return wrapper
 
     return decorator
+
+
+def _extract_token(obj: Any) -> Optional[str]:
+    """Attempt to extract an auth token from various object types."""
+
+    if obj is None:
+        return None
+
+    # Dictionary-like objects
+    if isinstance(obj, dict):
+        for key in ("token", "auth", "authorization"):
+            if key in obj and obj[key]:
+                return obj[key]
+        headers = obj.get("headers")
+        if isinstance(headers, dict):
+            for key in ("Authorization", "authorization", "token", "auth"):
+                if headers.get(key):
+                    return headers[key]
+        return None
+
+    # Objects with attributes
+    for key in ("token", "auth", "authorization"):
+        if hasattr(obj, key):
+            value = getattr(obj, key)
+            if value:
+                return value
+    if hasattr(obj, "headers"):
+        headers = getattr(obj, "headers")
+        if isinstance(headers, dict):
+            for key in ("Authorization", "authorization", "token", "auth"):
+                if headers.get(key):
+                    return headers[key]
+    return None
+
+
+def require_auth(func: T) -> T:
+    """Require a valid authentication token before executing the function."""
+
+    @functools.wraps(func)
+    async def wrapper(*args, **kwargs):
+        token = None
+
+        # Check common locations for context or request objects
+        for key in ("context", "request"):
+            if key in kwargs:
+                token = _extract_token(kwargs[key])
+                if token:
+                    break
+
+        if token is None and args:
+            # Fallback: inspect positional arguments
+            for arg in args:
+                token = _extract_token(arg)
+                if token:
+                    break
+
+        if token is None:
+            return SecuredResponse(
+                data=None,
+                trust_level=TrustLevel.UNTRUSTED,
+                warnings=[WARNING_AUTH_TOKEN_MISSING],
+            )
+
+        validator = config.auth_validator
+        valid = False
+        if callable(validator):
+            try:
+                valid = bool(validator(token))
+            except Exception:
+                valid = False
+
+        if not valid:
+            return SecuredResponse(
+                data=None,
+                trust_level=TrustLevel.UNTRUSTED,
+                warnings=[WARNING_AUTH_TOKEN_INVALID],
+            )
+
+        return await func(*args, **kwargs)
+
+    return wrapper
+
+
+def ratelimit(func: T) -> T:
+    """Apply a simple token bucket rate limiter to the decorated function."""
+
+    bucket = {"tokens": config.ratelimit_capacity, "last_refill": time.monotonic()}
+    lock = asyncio.Lock()
+
+    @functools.wraps(func)
+    async def wrapper(*args, **kwargs):
+        async with lock:
+            now = time.monotonic()
+            capacity = config.ratelimit_capacity
+            rate = config.ratelimit_refill_rate
+
+            # Refill tokens based on elapsed time
+            elapsed = now - bucket["last_refill"]
+            if elapsed > 0:
+                bucket["tokens"] = min(
+                    capacity, bucket["tokens"] + elapsed * rate
+                )
+                bucket["last_refill"] = now
+
+            if bucket["tokens"] < 1:
+                return SecuredResponse(
+                    data=None,
+                    trust_level=TrustLevel.UNTRUSTED,
+                    warnings=[WARNING_RATE_LIMIT_EXCEEDED],
+                )
+
+            bucket["tokens"] -= 1
+
+        return await func(*args, **kwargs)
+
+    return wrapper

--- a/safe_mcp/utils/patterns.py
+++ b/safe_mcp/utils/patterns.py
@@ -224,3 +224,6 @@ WARNING_CONFUSABLE_CHARACTERS_REPLACED = (
 WARNING_UNSAFE_DECORATOR_DEFAULT = "Data from untrusted external source"
 WARNING_SANITIZATION_SKIPPED = "Sanitization explicitly skipped."
 WARNING_INPUT_VALIDATION_FAILED = "Input validation failed"
+WARNING_AUTH_TOKEN_MISSING = "Authentication token missing"
+WARNING_AUTH_TOKEN_INVALID = "Invalid authentication token"
+WARNING_RATE_LIMIT_EXCEEDED = "Rate limit exceeded"

--- a/tests/test_auth_ratelimit.py
+++ b/tests/test_auth_ratelimit.py
@@ -1,0 +1,89 @@
+import asyncio
+import pytest
+
+from safe_mcp.decorators import require_auth, ratelimit
+from safe_mcp.core import SecuredResponse, TrustLevel
+from safe_mcp.config import config
+from safe_mcp.utils.patterns import (
+    WARNING_AUTH_TOKEN_INVALID,
+    WARNING_AUTH_TOKEN_MISSING,
+    WARNING_RATE_LIMIT_EXCEEDED,
+)
+
+
+@pytest.mark.asyncio
+async def test_require_auth_successful_authorization():
+    config.auth_validator = lambda token: token == "valid"
+
+    @require_auth
+    async def secured(context=None):
+        return "secret"
+
+    result = await secured(context={"token": "valid"})
+    assert result == "secret"
+
+    config.auth_validator = None
+
+
+@pytest.mark.asyncio
+async def test_require_auth_invalid_token():
+    config.auth_validator = lambda token: token == "valid"
+
+    @require_auth
+    async def secured(context=None):
+        return "secret"
+
+    result = await secured(context={"token": "invalid"})
+    assert isinstance(result, SecuredResponse)
+    assert result.trust_level == TrustLevel.UNTRUSTED
+    assert WARNING_AUTH_TOKEN_INVALID in result.warnings
+
+    config.auth_validator = None
+
+
+@pytest.mark.asyncio
+async def test_require_auth_missing_token():
+    config.auth_validator = lambda token: token == "valid"
+
+    @require_auth
+    async def secured(context=None):
+        return "secret"
+
+    result = await secured(context={})
+    assert isinstance(result, SecuredResponse)
+    assert result.trust_level == TrustLevel.UNTRUSTED
+    assert WARNING_AUTH_TOKEN_MISSING in result.warnings
+
+    config.auth_validator = None
+
+
+@pytest.mark.asyncio
+async def test_ratelimit_hits_and_refills():
+    config.ratelimit_capacity = 2
+    config.ratelimit_refill_rate = 1  # token per second
+
+    @ratelimit
+    async def limited():
+        return "ok"
+
+    # Use up available tokens
+    first = await limited()
+    second = await limited()
+
+    assert first == "ok"
+    assert second == "ok"
+
+    # Next call should be rate limited
+    third = await limited()
+    assert isinstance(third, SecuredResponse)
+    assert third.trust_level == TrustLevel.UNTRUSTED
+    assert WARNING_RATE_LIMIT_EXCEEDED in third.warnings
+
+    # Wait for refill
+    await asyncio.sleep(1.1)
+    fourth = await limited()
+    assert fourth == "ok"
+
+    # Reset to defaults
+    config.ratelimit_capacity = 60
+    config.ratelimit_refill_rate = 1.0


### PR DESCRIPTION
## Summary
- add global MCPConfig for auth and rate limit settings
- implement `require_auth` decorator to validate tokens from context/request
- implement token bucket `ratelimit` decorator
- provide tests for auth success/failure and rate limiting behaviour

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'pydantic')*
- `pip install pydantic` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6897194a7634832c82170c2925196b7a